### PR TITLE
PromisedScene fix - prevents overwrite of actor output when TPDB results are an empty performers array

### DIFF
--- a/plugins/PromisedScene/util.ts
+++ b/plugins/PromisedScene/util.ts
@@ -252,7 +252,7 @@ export const normalizeSceneResultData = (sceneData: SceneResult.SceneData): Scen
     result.thumbnail = sceneData.background.large;
   }
 
-  if (sceneData.performers) {
+  if (sceneData.performers?.length) {
     result.actors = sceneData.performers.map((p) => p.name);
   }
 


### PR DESCRIPTION
When piping plugins, PromisedScene currently overwrites the actors results with an empty array if TPDB has no known actors for a scene. 

This fixes it by returning no actors at all, instead of an empty array that overwrites the previous plugins actors from the combined plugin results.