### PR TITLE
Fix PromisedScene: would overwrite actors when piped, but tpdb had none

### DIFF
--- a/plugins/PromisedScene/docs.md
+++ b/plugins/PromisedScene/docs.md
@@ -14,6 +14,8 @@ If no match is found, and `manualTouch` is enabled, you will be able to interact
 
 ### Changelog
 
+- **0.4.3 - server 0.27**
+- - Fix: would remove actors when actors were piped, but tpdb returned no actors
 - **0.4.2 - server 0.27**
 - - Fix: labels were not being returned
 

--- a/plugins/PromisedScene/info.json
+++ b/plugins/PromisedScene/info.json
@@ -1,7 +1,7 @@
 {
   "name": "PromisedScene",
-  "version": "0.4.2",
-  "authors": ["Ch00nassid a.k.a: DGs.Ch00", "leadwolf"],
+  "version": "0.4.3",
+  "authors": ["Ch00nassid a.k.a: DGs.Ch00", "leadwolf", "arcadianCdr"],
   "description": "TPDB parser. Manual input possible: manual scene data entry, TPDB search result confirmation",
   "events": ["sceneCreated", "sceneCustom"],
   "arguments": [

--- a/plugins/PromisedScene/test/index.spec.js
+++ b/plugins/PromisedScene/test/index.spec.js
@@ -1359,6 +1359,53 @@ on top, pleasuring each other in unison, both of them squirming and squealing in
       expect(result.actors).to.contain("Abella Danger");
       expect(result.studio).to.equal("Blacked");
     });
+    it("Should not overwrite piped actors", async () => {
+      // I don't know the real actor, so use something that will still get a result in tpdb
+      const pipedActor = "TeppanVR";
+
+      const result = await runPlugin({
+        ...mockContext,
+        event: "sceneCreated",
+        scene: {},
+        $getStudio: async () => {},
+        $getMovies: async () => [],
+        $getActors: async () => [],
+        args: {
+          manualTouch: false,
+          sceneDuplicationCheck: true,
+          parseActor: true,
+          parseStudio: true,
+          parseDate: true,
+          usePipedInputInSearch: true,
+          alwaysUseSingleResult: true,
+          useTitleInSearch: true,
+          source_settings: {
+            actors: "./plugins/PromisedScene/test/fixtures/actorsPopulated.db",
+            scenes: "./plugins/PromisedScene/test/fixtures/scenesPopulated.db",
+            studios: "./plugins/PromisedScene/test/fixtures/studiosPopulated.db",
+          },
+        },
+        sceneName:
+          "Passionate Sex With A Woman That Has Decadent Overflowing Tits In Erotic Cosplay",
+        scenePath:
+          "Z:\\Keep\\test\\Passionate Sex With A Woman That Has Decadent Overflowing Tits In Erotic Cosplay",
+        // Piped data that should take precedence
+        data: {
+          actors: [pipedActor],
+          studio: "",
+          releaseDate: null,
+        },
+        testMode: {
+          correctImportInfo: "y",
+          testSiteUnavailable: false,
+          status: true,
+        },
+      });
+      expect(result).to.be.an("object");
+      expect(result.actors).to.be.a("Array");
+      // Even though tpdb has no actors for the scene, the piped actor should still be here
+      expect(result.actors).to.contain(pipedActor);
+    });
     it("Should use and match movie/actor(s) piped data (when they exist and are enabled through config)", async () => {
       const result = await runPlugin({
         ...mockContext,

--- a/plugins/PromisedScene/test/index.spec.js
+++ b/plugins/PromisedScene/test/index.spec.js
@@ -21,7 +21,7 @@ describe("PromisedScene", () => {
           ...mockContext,
           event: "fake event",
           scene: {},
-          $getStudio: async () => {},
+          $getStudio: async () => ({}),
           $getMovies: async () => [],
           $getActors: async () => [],
           args: {

--- a/plugins/PromisedScene/util.ts
+++ b/plugins/PromisedScene/util.ts
@@ -342,7 +342,7 @@ export const normalizeSceneResultData = (sceneData: SceneResult.SceneData): Scen
     result.thumbnail = sceneData.background.large;
   }
 
-  if (sceneData.performers) {
+  if (sceneData.performers?.length) {
     result.actors = sceneData.performers.map((p) => p.name);
   }
 


### PR DESCRIPTION
Copied from #270
> When piping plugins, PromisedScene currently overwrites the actors results with an empty array if TPDB has no known actors for a scene.
> 
> This fixes it by returning no actors at all, instead of an empty array that overwrites the previous plugins actors from the combined plugin results.
